### PR TITLE
Changed location of search-json output file

### DIFF
--- a/services/getSearchResults.py
+++ b/services/getSearchResults.py
@@ -22,7 +22,7 @@ def getSearchResults(searchTerm, display=None):
     functionality similar to grep -ir <term>
     """
     start = time.time()
-    path = './services'
+    path = './falcon'
     fileName = 'search_output'
     searchTerms = searchTerm.split()
     results = []


### PR DESCRIPTION
### Changes Proposed
Change the location of output-json file for search feature.


Due to current location, some ***error*** was comming in search feature.
Error of current code-base while running search feature command : 
```
code greedy algorithms
greedy algorithms
greedy algorithms kruskal minimum spanning tree
Traceback (most recent call last):
  File "/home/dataone-5/.local/share/virtualenvs/OS-70Uo2k3h/bin/openfalcon", line 11, in <module>
    load_entry_point('openfalcon', 'console_scripts', 'openfalcon')()
  File "/home/dataone-5/Desktop/Nisarg Shah/OS/falcon/services/openfalcon.py", line 89, in main
    search.main(args.search, args.results)
  File "/home/dataone-5/Desktop/Nisarg Shah/OS/falcon/services/search.py", line 26, in main
    print(getSearchResults.getSearchResults(searchTerm, display))
  File "/home/dataone-5/Desktop/Nisarg Shah/OS/falcon/services/getSearchResults.py", line 56, in getSearchResults
    writeToJSONFile(path, fileName, jsonData)
  File "/home/dataone-5/Desktop/Nisarg Shah/OS/falcon/services/getSearchResults.py", line 16, in writeToJSONFile
    with open(filePathNameWithExt, 'w') as fp:

```

### Desired Reviewers
@AdiChat 